### PR TITLE
Fix security & data-integrity bugs (issues #1 #2 #4 #5 #6)

### DIFF
--- a/alembic/versions/002_parent_pupil_link.py
+++ b/alembic/versions/002_parent_pupil_link.py
@@ -1,0 +1,40 @@
+"""Add parent_id FK to pupils (issue #2: parent-pupil ownership)
+
+Revision ID: 002
+Revises: 001
+Create Date: 2026-02-24 00:00:00.000000
+
+Bootstrap note: existing pupils will have parent_id=NULL. Admins should assign
+parent_id values via the admin API or directly in the DB before enforcing
+ownership in a multi-family deployment.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "002"
+down_revision: Union[str, None] = "001"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "pupils",
+        sa.Column("parent_id", sa.Integer(), nullable=True),
+    )
+    op.create_foreign_key(
+        "fk_pupils_parent_id",
+        "pupils",
+        "parents",
+        ["parent_id"],
+        ["id"],
+    )
+    op.create_index("ix_pupils_parent_id", "pupils", ["parent_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_pupils_parent_id", table_name="pupils")
+    op.drop_constraint("fk_pupils_parent_id", "pupils", type_="foreignkey")
+    op.drop_column("pupils", "parent_id")

--- a/alembic/versions/003_report_unique_constraint.py
+++ b/alembic/versions/003_report_unique_constraint.py
@@ -1,0 +1,29 @@
+"""Add unique constraint on reports(pupil_id, report_type, period_start) (issue #5: idempotency)
+
+Revision ID: 003
+Revises: 002
+Create Date: 2026-02-24 00:00:00.000000
+
+Note: if duplicate reports already exist in the DB, remove them before running
+this migration (keep the row with the lowest id per group).
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "003"
+down_revision: Union[str, None] = "002"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_unique_constraint(
+        "uq_report_identity",
+        "reports",
+        ["pupil_id", "report_type", "period_start"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("uq_report_identity", "reports", type_="unique")

--- a/app/crud/pupils.py
+++ b/app/crud/pupils.py
@@ -17,8 +17,12 @@ class CRUDPupil(CRUDBase[Pupil, PupilCreate, PupilUpdate]):
         result = await db.execute(select(Pupil).where(Pupil.is_active == True))
         return result.scalars().all()
 
+    async def get_by_parent(self, db: AsyncSession, parent_id: int) -> Sequence[Pupil]:
+        result = await db.execute(select(Pupil).where(Pupil.parent_id == parent_id))
+        return result.scalars().all()
+
     async def create(self, db: AsyncSession, *, obj_in: PupilCreate) -> Pupil:
-        data = obj_in.model_dump(exclude={"parent_id"})
+        data = obj_in.model_dump()  # parent_id is now persisted
         db_obj = Pupil(**data)
         db.add(db_obj)
         await db.flush()

--- a/app/models/parent.py
+++ b/app/models/parent.py
@@ -1,7 +1,12 @@
+from typing import TYPE_CHECKING
+
 from sqlalchemy import BigInteger, Boolean, Integer, String
-from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.models.base import Base, TimestampMixin
+
+if TYPE_CHECKING:
+    from app.models.pupil import Pupil
 
 
 class Parent(Base, TimestampMixin):
@@ -11,3 +16,6 @@ class Parent(Base, TimestampMixin):
     name: Mapped[str] = mapped_column(String(100), nullable=False)
     telegram_chat_id: Mapped[int] = mapped_column(BigInteger, unique=True, nullable=False)
     is_admin: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
+
+    # Relationships
+    children: Mapped[list["Pupil"]] = relationship("Pupil", back_populates="parent")

--- a/app/models/pupil.py
+++ b/app/models/pupil.py
@@ -1,13 +1,14 @@
 from datetime import date
 from typing import TYPE_CHECKING, Optional
 
-from sqlalchemy import BigInteger, Boolean, Date, Integer, String
+from sqlalchemy import BigInteger, Boolean, Date, ForeignKey, Integer, String
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.models.base import Base, TimestampMixin
 
 if TYPE_CHECKING:
     from app.models.check_in import CheckIn
+    from app.models.parent import Parent
     from app.models.target import Target
     from app.models.achievement import Achievement
     from app.models.notification import Notification
@@ -18,6 +19,9 @@ class Pupil(Base, TimestampMixin):
     __tablename__ = "pupils"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    parent_id: Mapped[Optional[int]] = mapped_column(
+        Integer, ForeignKey("parents.id"), nullable=True, index=True
+    )
     name: Mapped[str] = mapped_column(String(100), nullable=False)
     display_name: Mapped[str] = mapped_column(String(50), nullable=False)
     grade: Mapped[str] = mapped_column(String(20), nullable=False)
@@ -29,6 +33,7 @@ class Pupil(Base, TimestampMixin):
     is_active: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
 
     # Relationships
+    parent: Mapped[Optional["Parent"]] = relationship("Parent", back_populates="children")
     targets: Mapped[list["Target"]] = relationship("Target", back_populates="pupil")
     check_ins: Mapped[list["CheckIn"]] = relationship("CheckIn", back_populates="pupil")
     achievements: Mapped[list["Achievement"]] = relationship("Achievement", back_populates="pupil")

--- a/app/models/report.py
+++ b/app/models/report.py
@@ -2,7 +2,7 @@ import enum
 from datetime import date
 from typing import TYPE_CHECKING, Optional
 
-from sqlalchemy import Boolean, Date, Enum, ForeignKey, Integer, MediumText, String
+from sqlalchemy import Boolean, Date, Enum, ForeignKey, Integer, String, UniqueConstraint
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.models.base import Base, TimestampMixin
@@ -29,6 +29,9 @@ class ReportType(str, enum.Enum):
 
 class Report(Base, TimestampMixin):
     __tablename__ = "reports"
+    __table_args__ = (
+        UniqueConstraint("pupil_id", "report_type", "period_start", name="uq_report_identity"),
+    )
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
     pupil_id: Mapped[int] = mapped_column(Integer, ForeignKey("pupils.id"), nullable=False)

--- a/app/schemas/pupil.py
+++ b/app/schemas/pupil.py
@@ -26,6 +26,7 @@ class PupilResponse(PupilBase):
     model_config = {"from_attributes": True}
 
     id: int
+    parent_id: Optional[int]
     xp_total: int
     streak_current: int
     streak_longest: int

--- a/tests/unit/test_checkin_validation.py
+++ b/tests/unit/test_checkin_validation.py
@@ -1,0 +1,130 @@
+"""Tests for issue #1: check-in task ownership and date eligibility validation."""
+from datetime import date, timedelta
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import select
+
+from app.models.parent import Parent
+from app.models.pupil import Pupil
+from app.models.target import Target, VacationType, TargetStatus
+from app.models.plan import Plan, PlanStatus
+from app.models.weekly_milestone import WeeklyMilestone
+from app.models.task import Task, TaskType
+from app.crud.tasks import crud_task
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _monday_of_current_week() -> date:
+    today = date.today()
+    return today - timedelta(days=today.weekday())
+
+
+@pytest_asyncio.fixture
+async def family(db):
+    """Minimal fixture: one parent, two pupils, one plan each."""
+    parent = Parent(name="Parent", telegram_chat_id=1000, is_admin=False)
+    db.add(parent)
+    await db.flush()
+
+    pupil_a = Pupil(
+        parent_id=parent.id, name="Alice", display_name="Alice",
+        grade="5", telegram_chat_id=2001,
+    )
+    pupil_b = Pupil(
+        parent_id=parent.id, name="Bob", display_name="Bob",
+        grade="5", telegram_chat_id=2002,
+    )
+    db.add_all([pupil_a, pupil_b])
+    await db.flush()
+
+    today = date.today()
+    week_start = _monday_of_current_week()
+    week_end = week_start + timedelta(days=6)
+
+    for pupil in (pupil_a, pupil_b):
+        target = Target(
+            pupil_id=pupil.id, title="Math", subject="Math",
+            description="", vacation_type=VacationType.summer,
+            vacation_year=today.year, status=TargetStatus.active,
+        )
+        db.add(target)
+        await db.flush()
+
+        plan = Plan(
+            target_id=target.id, title="Plan", overview="",
+            start_date=week_start, end_date=week_end,
+            total_weeks=1, status=PlanStatus.active,
+        )
+        db.add(plan)
+        await db.flush()
+
+        milestone = WeeklyMilestone(
+            plan_id=plan.id, week_number=1, title="W1", description="",
+            start_date=week_start, end_date=week_end,
+            total_tasks=1, completed_tasks=0,
+        )
+        db.add(milestone)
+        await db.flush()
+
+        task = Task(
+            milestone_id=milestone.id,
+            day_of_week=today.weekday(),
+            sequence_in_day=1,
+            title="Task", description="", estimated_minutes=30,
+            xp_reward=10, task_type=TaskType.practice, is_optional=False,
+        )
+        db.add(task)
+
+    await db.flush()
+    await db.refresh(pupil_a)
+    await db.refresh(pupil_b)
+    return pupil_a, pupil_b
+
+
+@pytest.mark.asyncio
+async def test_get_with_ownership_correct_pupil(db, family):
+    pupil_a, pupil_b = family
+    tasks_a = await crud_task.get_tasks_for_day(db, pupil_a.id, date.today())
+    assert tasks_a, "Fixture must create a task for today"
+    task = tasks_a[0]
+
+    result = await crud_task.get_with_ownership(db, task.id, pupil_a.id)
+    assert result is not None
+    assert result.id == task.id
+
+
+@pytest.mark.asyncio
+async def test_get_with_ownership_wrong_pupil(db, family):
+    """Cross-pupil spoofing: task belongs to pupil_a, pupil_b tries to claim it."""
+    pupil_a, pupil_b = family
+    tasks_a = await crud_task.get_tasks_for_day(db, pupil_a.id, date.today())
+    task = tasks_a[0]
+
+    result = await crud_task.get_with_ownership(db, task.id, pupil_b.id)
+    assert result is None, "Ownership check must reject cross-pupil access"
+
+
+@pytest.mark.asyncio
+async def test_get_eligible_for_date_today(db, family):
+    pupil_a, _ = family
+    tasks_a = await crud_task.get_tasks_for_day(db, pupil_a.id, date.today())
+    task = tasks_a[0]
+
+    result = await crud_task.get_eligible_for_date(db, task.id, pupil_a.id, date.today())
+    assert result is not None
+
+
+@pytest.mark.asyncio
+async def test_get_eligible_for_date_wrong_day(db, family):
+    """Task scheduled for today must not be eligible for tomorrow."""
+    pupil_a, _ = family
+    tasks_a = await crud_task.get_tasks_for_day(db, pupil_a.id, date.today())
+    task = tasks_a[0]
+
+    tomorrow = date.today() + timedelta(days=1)
+    result = await crud_task.get_eligible_for_date(db, task.id, pupil_a.id, tomorrow)
+    assert result is None, "Date eligibility check must reject wrong day"

--- a/tests/unit/test_parent_ownership.py
+++ b/tests/unit/test_parent_ownership.py
@@ -1,0 +1,73 @@
+"""Tests for issue #2: parent-pupil ownership model."""
+import pytest
+import pytest_asyncio
+
+from app.crud.pupils import crud_pupil
+from app.crud.parents import crud_parent
+from app.models.parent import Parent
+from app.models.pupil import Pupil
+from app.schemas.pupil import PupilCreate
+
+
+@pytest_asyncio.fixture
+async def two_families(db):
+    parent_a = Parent(name="ParentA", telegram_chat_id=3001, is_admin=False)
+    parent_b = Parent(name="ParentB", telegram_chat_id=3002, is_admin=False)
+    db.add_all([parent_a, parent_b])
+    await db.flush()
+
+    pupil_a = await crud_pupil.create(
+        db,
+        obj_in=PupilCreate(
+            name="Alice", display_name="Alice", grade="5",
+            telegram_chat_id=4001, parent_id=parent_a.id,
+        ),
+    )
+    pupil_b = await crud_pupil.create(
+        db,
+        obj_in=PupilCreate(
+            name="Bob", display_name="Bob", grade="6",
+            telegram_chat_id=4002, parent_id=parent_b.id,
+        ),
+    )
+    return parent_a, parent_b, pupil_a, pupil_b
+
+
+@pytest.mark.asyncio
+async def test_create_pupil_persists_parent_id(db, two_families):
+    """crud_pupil.create() must now persist parent_id (was previously dropped)."""
+    parent_a, _, pupil_a, _ = two_families
+    fetched = await crud_pupil.get(db, pupil_a.id)
+    assert fetched.parent_id == parent_a.id
+
+
+@pytest.mark.asyncio
+async def test_get_by_parent_returns_own_children(db, two_families):
+    parent_a, parent_b, pupil_a, pupil_b = two_families
+    children_a = await crud_pupil.get_by_parent(db, parent_a.id)
+    ids_a = {p.id for p in children_a}
+    assert pupil_a.id in ids_a
+    assert pupil_b.id not in ids_a
+
+
+@pytest.mark.asyncio
+async def test_get_by_parent_isolation(db, two_families):
+    parent_a, parent_b, pupil_a, pupil_b = two_families
+    children_b = await crud_pupil.get_by_parent(db, parent_b.id)
+    ids_b = {p.id for p in children_b}
+    assert pupil_b.id in ids_b
+    assert pupil_a.id not in ids_b
+
+
+@pytest.mark.asyncio
+async def test_pupil_without_parent_id(db):
+    """Pupils may be created without a parent_id (nullable FK)."""
+    pupil = await crud_pupil.create(
+        db,
+        obj_in=PupilCreate(
+            name="Orphan", display_name="Orphan", grade="3",
+            telegram_chat_id=5999,
+        ),
+    )
+    fetched = await crud_pupil.get(db, pupil.id)
+    assert fetched.parent_id is None

--- a/tests/unit/test_plan_activation.py
+++ b/tests/unit/test_plan_activation.py
@@ -1,0 +1,123 @@
+"""Tests for issue #4: single active plan invariant per pupil."""
+from datetime import date, timedelta
+from unittest.mock import AsyncMock, patch
+
+import pytest
+import pytest_asyncio
+
+from app.models.parent import Parent
+from app.models.pupil import Pupil
+from app.models.target import Target, VacationType, TargetStatus
+from app.models.plan import Plan, PlanStatus
+from app.crud.plans import crud_plan
+
+
+@pytest_asyncio.fixture
+async def pupil_with_target(db):
+    parent = Parent(name="P", telegram_chat_id=6001, is_admin=False)
+    db.add(parent)
+    await db.flush()
+
+    pupil = Pupil(
+        parent_id=parent.id, name="Charlie", display_name="Charlie",
+        grade="4", telegram_chat_id=6002,
+    )
+    db.add(pupil)
+    await db.flush()
+
+    target = Target(
+        pupil_id=pupil.id, title="English", subject="English",
+        description="", vacation_type=VacationType.summer,
+        vacation_year=date.today().year, status=TargetStatus.active,
+    )
+    db.add(target)
+    await db.flush()
+    return pupil, target
+
+
+@pytest.mark.asyncio
+async def test_generate_plan_deactivates_prior_active_plan(db, pupil_with_target):
+    """Generating a second plan must mark the first plan as completed."""
+    pupil, target = pupil_with_target
+    today = date.today()
+
+    # Create an existing active plan manually
+    old_plan = Plan(
+        target_id=target.id, title="Old Plan", overview="",
+        start_date=today, end_date=today + timedelta(days=6),
+        total_weeks=1, status=PlanStatus.active,
+    )
+    db.add(old_plan)
+    await db.flush()
+
+    assert old_plan.status == PlanStatus.active
+
+    # Patch llm_service so we don't make real API calls
+    fake_plan_data = {
+        "title": "New Plan",
+        "overview": "overview",
+        "weeks": [],
+    }
+    with patch(
+        "app.services.plan_generator.llm_service.chat_complete_long",
+        new_callable=AsyncMock,
+        return_value=(
+            __import__("json").dumps(fake_plan_data),
+            10, 20,
+        ),
+    ):
+        from app.services.plan_generator import generate_plan
+        new_plan = await generate_plan(
+            db=db,
+            target=target,
+            pupil_name=pupil.name,
+            grade=pupil.grade,
+            start_date=today + timedelta(days=7),
+            end_date=today + timedelta(days=13),
+            daily_study_minutes=60,
+            preferred_days=[0, 1, 2, 3, 4],
+        )
+
+    await db.refresh(old_plan)
+    assert old_plan.status == PlanStatus.completed, (
+        "Prior active plan must be deactivated when a new plan is generated"
+    )
+    assert new_plan.status == PlanStatus.active
+
+
+@pytest.mark.asyncio
+async def test_only_one_active_plan_after_generate(db, pupil_with_target):
+    """After generation, at most one plan should be active for the pupil."""
+    pupil, target = pupil_with_target
+    today = date.today()
+
+    fake_plan_data = {"title": "P", "overview": "o", "weeks": []}
+    with patch(
+        "app.services.plan_generator.llm_service.chat_complete_long",
+        new_callable=AsyncMock,
+        return_value=(__import__("json").dumps(fake_plan_data), 5, 10),
+    ):
+        from app.services.plan_generator import generate_plan
+        await generate_plan(
+            db=db, target=target, pupil_name=pupil.name, grade=pupil.grade,
+            start_date=today, end_date=today + timedelta(days=6),
+            daily_study_minutes=60, preferred_days=[0],
+        )
+        await generate_plan(
+            db=db, target=target, pupil_name=pupil.name, grade=pupil.grade,
+            start_date=today + timedelta(days=7), end_date=today + timedelta(days=13),
+            daily_study_minutes=60, preferred_days=[0],
+        )
+
+    active_plan = await crud_plan.get_active_for_pupil(db, pupil.id)
+    assert active_plan is not None
+
+    from sqlalchemy import select
+    from app.models.target import Target as T
+    result = await db.execute(
+        select(Plan)
+        .join(T, Plan.target_id == T.id)
+        .where(T.pupil_id == pupil.id, Plan.status == PlanStatus.active)
+    )
+    active_plans = result.scalars().all()
+    assert len(active_plans) == 1, f"Expected 1 active plan, got {len(active_plans)}"

--- a/tests/unit/test_report_idempotency.py
+++ b/tests/unit/test_report_idempotency.py
@@ -1,0 +1,169 @@
+"""Tests for issues #5 and #6: idempotent report generation and period filtering."""
+from datetime import date, datetime, timedelta, timezone
+from unittest.mock import AsyncMock, patch
+
+import pytest
+import pytest_asyncio
+
+from app.models.parent import Parent
+from app.models.pupil import Pupil
+from app.models.check_in import CheckIn, CheckInStatus
+from app.models.report import Report, ReportType
+from app.crud.reports import crud_report
+
+
+@pytest_asyncio.fixture
+async def pupil(db):
+    parent = Parent(name="P2", telegram_chat_id=7001, is_admin=False)
+    db.add(parent)
+    await db.flush()
+    p = Pupil(
+        parent_id=parent.id, name="Diana", display_name="Diana",
+        grade="6", telegram_chat_id=7002,
+    )
+    db.add(p)
+    await db.flush()
+    return p
+
+
+# ---------------------------------------------------------------------------
+# Issue #5: idempotency
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_daily_report_is_idempotent(db, pupil):
+    """Calling generate_daily_report twice must return the same report id."""
+    report_date = date.today()
+    fake_md = "# Report\n\nGood job."
+
+    with patch(
+        "app.services.report_service.llm_service.chat_complete",
+        new_callable=AsyncMock,
+        return_value=(fake_md, 10, 20),
+    ), patch(
+        "app.services.report_service.github_service.commit_report",
+        new_callable=AsyncMock,
+        return_value=("abc123", "reports/file.md"),
+    ):
+        from app.services.report_service import generate_daily_report
+        r1 = await generate_daily_report(db, pupil, report_date)
+        r2 = await generate_daily_report(db, pupil, report_date)
+
+    assert r1.id == r2.id, "Repeated calls must return the same report (idempotent)"
+
+
+@pytest.mark.asyncio
+async def test_weekly_report_is_idempotent(db, pupil):
+    today = date.today()
+    week_start = today - timedelta(days=today.weekday())
+    fake_md = "# Weekly"
+
+    with patch(
+        "app.services.report_service.llm_service.chat_complete",
+        new_callable=AsyncMock,
+        return_value=(fake_md, 10, 20),
+    ), patch(
+        "app.services.report_service.github_service.commit_report",
+        new_callable=AsyncMock,
+        return_value=("sha", "path"),
+    ):
+        from app.services.report_service import generate_weekly_report
+        r1 = await generate_weekly_report(db, pupil, week_start)
+        r2 = await generate_weekly_report(db, pupil, week_start)
+
+    assert r1.id == r2.id
+
+
+@pytest.mark.asyncio
+async def test_monthly_report_is_idempotent(db, pupil):
+    today = date.today()
+    fake_md = "# Monthly"
+
+    with patch(
+        "app.services.report_service.llm_service.chat_complete",
+        new_callable=AsyncMock,
+        return_value=(fake_md, 10, 20),
+    ), patch(
+        "app.services.report_service.github_service.commit_report",
+        new_callable=AsyncMock,
+        return_value=("sha", "path"),
+    ):
+        from app.services.report_service import generate_monthly_report
+        r1 = await generate_monthly_report(db, pupil, today.year, today.month)
+        r2 = await generate_monthly_report(db, pupil, today.year, today.month)
+
+    assert r1.id == r2.id
+
+
+# ---------------------------------------------------------------------------
+# Issue #6: period filtering uses actual check-in timestamp
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_fetch_check_ins_filters_by_created_at(db, pupil):
+    """Check-ins must be filtered by their created_at date, not milestone coverage."""
+    today = date.today()
+    yesterday = today - timedelta(days=1)
+
+    # Set created_at explicitly to avoid relying on server_default in SQLite
+    ci_today = CheckIn(
+        task_id=1, pupil_id=pupil.id, status=CheckInStatus.completed,
+        xp_earned=10, streak_at_checkin=1,
+        created_at=datetime.combine(today, datetime.min.time()),
+        updated_at=datetime.combine(today, datetime.min.time()),
+    )
+    ci_yesterday = CheckIn(
+        task_id=2, pupil_id=pupil.id, status=CheckInStatus.completed,
+        xp_earned=5, streak_at_checkin=1,
+        created_at=datetime.combine(yesterday, datetime.min.time()),
+        updated_at=datetime.combine(yesterday, datetime.min.time()),
+    )
+    db.add_all([ci_today, ci_yesterday])
+    await db.flush()
+
+    from app.services.report_service import _fetch_check_ins
+    only_today = await _fetch_check_ins(db, pupil.id, today, today)
+    ids = {c.id for c in only_today}
+    assert ci_today.id in ids, "Today's check-in must be included"
+    assert ci_yesterday.id not in ids, "Yesterday's check-in must be excluded from daily filter"
+
+
+@pytest.mark.asyncio
+async def test_daily_report_excludes_other_days(db, pupil):
+    """Daily report stats must only count check-ins from the target day."""
+    today = date.today()
+    yesterday = today - timedelta(days=1)
+
+    ci_today = CheckIn(
+        task_id=10, pupil_id=pupil.id, status=CheckInStatus.completed,
+        xp_earned=15, streak_at_checkin=2,
+        created_at=datetime.combine(today, datetime.min.time()),
+        updated_at=datetime.combine(today, datetime.min.time()),
+    )
+    ci_yesterday = CheckIn(
+        task_id=11, pupil_id=pupil.id, status=CheckInStatus.completed,
+        xp_earned=20, streak_at_checkin=1,
+        created_at=datetime.combine(yesterday, datetime.min.time()),
+        updated_at=datetime.combine(yesterday, datetime.min.time()),
+    )
+    db.add_all([ci_today, ci_yesterday])
+    await db.flush()
+
+    fake_md = "# Daily"
+    with patch(
+        "app.services.report_service.llm_service.chat_complete",
+        new_callable=AsyncMock,
+        return_value=(fake_md, 5, 10),
+    ), patch(
+        "app.services.report_service.github_service.commit_report",
+        new_callable=AsyncMock,
+        return_value=("sha", "path"),
+    ):
+        from app.services.report_service import generate_daily_report
+        report = await generate_daily_report(db, pupil, today)
+
+    # Only today's check-in (xp=15) should be counted
+    assert report.xp_earned == 15, (
+        f"Daily report must only include today's XP (15), got {report.xp_earned}"
+    )
+    assert report.tasks_completed == 1


### PR DESCRIPTION
## Summary

- **#1 (P0)** Validate check-in task ownership + date before awarding XP — prevents cross-pupil task spoofing (403) and out-of-date check-ins (422)
- **#2 (P0)** Add `parent_id` FK on `pupils`, parent→children relationship, fix `crud_pupil.create()` dropping the FK, and enforce parent-owns-pupil checks in all targets/plans/reports endpoints
- **#4 (P1)** Single-active-plan invariant — `generate_plan()` now deactivates prior active plans before activating the new one
- **#5 (P1)** Idempotent report generation — `get_existing()` guard at start of each generate function; DB-level `UniqueConstraint` on `(pupil_id, report_type, period_start)`
- **#6 (P1)** Report period filtering fixed — `_fetch_check_ins` now uses `func.date(CheckIn.created_at)` instead of milestone date ranges, eliminating daily overcount

## Migrations

| # | File | Change |
|---|------|--------|
| 002 | `alembic/versions/002_parent_pupil_link.py` | Add `parent_id` FK + index to `pupils` |
| 003 | `alembic/versions/003_report_unique_constraint.py` | Add `uq_report_identity` unique constraint on `reports` |

> **Bootstrap note (002):** existing pupils will have `parent_id=NULL`. Assign via admin API before enabling ownership enforcement in multi-family deployments.
> **Pre-condition (003):** remove duplicate report rows (keep lowest `id` per group) before running migration if DB already has data.

## Test plan

- [x] `tests/unit/test_checkin_validation.py` — ownership + date eligibility (4 cases)
- [x] `tests/unit/test_parent_ownership.py` — parent_id persistence + family isolation (4 cases)
- [x] `tests/unit/test_plan_activation.py` — single-active-plan deactivation (2 cases)
- [x] `tests/unit/test_report_idempotency.py` — idempotency + period filtering (5 cases)
- [x] All 22 unit tests pass (`pytest tests/unit/ -q`)

Closes #1, #2, #4, #5, #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)