### PR TITLE
Fix pyproject [tool.uv] compatibility (closes #9)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,12 +40,8 @@ packages = ["app"]
 # ---------------------------------------------------------------------------
 # uv
 # ---------------------------------------------------------------------------
-[tool.uv]
-# Pin the Python version used by `uv venv` / `uv sync`
-python = "3.12"
-
-[tool.uv.sources]
-# (add private index overrides here if needed)
+# Python version is pinned in [project] requires-python = ">=3.12"
+# No additional [tool.uv] config needed for uv >= 0.5.x
 
 # ---------------------------------------------------------------------------
 # pytest


### PR DESCRIPTION
## Summary

Fix pyproject.toml compatibility with uv 0.5.x by removing invalid `[tool.uv] python = "3.12"` field.

## Changes

- Removed invalid `[tool.uv] python = "3.12"` from pyproject.toml
- Python version is already specified in `[project] requires-python = ">=3.12"`

## Test plan

- [x] `uv sync --dev` works without errors
- [x] `uv run pytest tests/ -q` → **52 passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)