### PR TITLE
feat: Tavily as primary search with Brave as quota fallback

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,7 +30,10 @@ GITHUB_DATA_REPO=username/study-data-private
 GITHUB_COMMITTER_NAME="Goal Agent Bot"
 GITHUB_COMMITTER_EMAIL=bot@example.com
 
-# Brave Search API (https://brave.com/search/api/ — use "Data for Search" plan, not "Data for AI")
+# Web search — Tavily first, falls back to Brave on HTTP 429 (quota) or any error
+# Tavily: https://app.tavily.com  (free tier: 1 000 req/month)
+TAVILY_API_KEY=
+# Brave: https://brave.com/search/api/ — use "Data for Search" plan, not "Data for AI"
 BRAVE_API_KEY=
 
 # App

--- a/app/config.py
+++ b/app/config.py
@@ -40,7 +40,8 @@ class Settings(BaseSettings):
     # Leave empty in dev/test environments to skip verification.
     HMAC_SECRET: str = ""
 
-    # Brave Search API
+    # Web search (Tavily primary, Brave fallback on quota)
+    TAVILY_API_KEY: str = ""
     BRAVE_API_KEY: str = ""
 
     # Bootstrap admin chat IDs (comma-separated)

--- a/app/services/web_research_service.py
+++ b/app/services/web_research_service.py
@@ -1,4 +1,13 @@
-"""Web research service: search for Chinese curriculum materials via Brave Search."""
+"""Web research service: search for Chinese curriculum materials.
+
+Provider strategy:
+  1. Tavily (primary) — richer content field, better RAG quality
+  2. Brave Search (fallback) — used when Tavily quota is exhausted (HTTP 429)
+     or when TAVILY_API_KEY is not set
+
+Both providers return a normalised list[{title, url, content}] consumed by
+_extract_materials(). Callers see no difference.
+"""
 
 from __future__ import annotations
 
@@ -13,7 +22,8 @@ from app.services import llm_service
 
 logger = logging.getLogger(__name__)
 
-_BRAVE_SEARCH_ENDPOINT = "https://api.search.brave.com/res/v1/web/search"
+_TAVILY_ENDPOINT = "https://api.tavily.com/search"
+_BRAVE_ENDPOINT = "https://api.search.brave.com/res/v1/web/search"
 
 _GRADE_CN = {
     "1": "一",
@@ -60,32 +70,63 @@ def _build_query(subject: str, grade: str, description: str) -> str:
     return " ".join(parts)
 
 
+async def _tavily_search(query: str, n_results: int = 5) -> list[dict]:
+    """Search via Tavily API.
+
+    Returns normalised list[{title, url, content}].
+    Raises httpx.HTTPStatusError on HTTP errors (caller checks status_code for 429).
+    Raises other exceptions on network / parse failures.
+    """
+    settings = get_settings()
+    async with httpx.AsyncClient(timeout=15.0) as client:
+        response = await client.post(
+            _TAVILY_ENDPOINT,
+            json={
+                "api_key": settings.TAVILY_API_KEY,
+                "query": query,
+                "max_results": n_results,
+                "include_answer": False,
+            },
+            headers={"Content-Type": "application/json"},
+        )
+        response.raise_for_status()
+        results = response.json().get("results", [])[:n_results]
+        return [
+            {
+                "title": r.get("title", ""),
+                "url": r.get("url", ""),
+                "content": r.get("content", ""),
+            }
+            for r in results
+        ]
+
+
 async def _brave_search(query: str, n_results: int = 5) -> list[dict]:
-    """Search via Brave Search API. Returns list of result dicts."""
+    """Search via Brave Search API.
+
+    Returns normalised list[{title, url, content}]. Returns [] on any error.
+    """
     settings = get_settings()
     if not settings.BRAVE_API_KEY:
-        logger.warning("BRAVE_API_KEY not set; skipping web search")
+        logger.warning("BRAVE_API_KEY not set; cannot fall back to Brave")
         return []
     params = urlencode({"q": query, "count": n_results, "search_lang": "zh", "country": "CN"})
-    url = f"{_BRAVE_SEARCH_ENDPOINT}?{params}"
     try:
         async with httpx.AsyncClient(timeout=10.0) as client:
             response = await client.get(
-                url,
+                f"{_BRAVE_ENDPOINT}?{params}",
                 headers={
                     "Accept": "application/json",
                     "X-Subscription-Token": settings.BRAVE_API_KEY,
                 },
             )
             response.raise_for_status()
-            data = response.json()
-            results = data.get("web", {}).get("results", [])[:n_results]
-            # Normalise to {title, url, description} — same shape as before
+            results = response.json().get("web", {}).get("results", [])[:n_results]
             return [
                 {
                     "title": r.get("title", ""),
                     "url": r.get("url", ""),
-                    "description": r.get("description", ""),
+                    "content": r.get("description", ""),  # Brave returns snippets, not full content
                 }
                 for r in results
             ]
@@ -94,14 +135,46 @@ async def _brave_search(query: str, n_results: int = 5) -> list[dict]:
         return []
 
 
+async def _search_with_fallback(query: str, n_results: int = 5) -> list[dict]:
+    """Try Tavily; fall back to Brave on quota (429) or any failure."""
+    settings = get_settings()
+
+    if settings.TAVILY_API_KEY:
+        try:
+            results = await _tavily_search(query, n_results)
+            logger.debug("Tavily search returned %d results", len(results))
+            return results
+        except httpx.HTTPStatusError as exc:
+            if exc.response.status_code == 429:
+                logger.warning(
+                    "Tavily quota exhausted (HTTP 429); falling back to Brave Search"
+                )
+            else:
+                logger.warning(
+                    "Tavily search HTTP error %d for query=%r; falling back to Brave Search",
+                    exc.response.status_code,
+                    query,
+                )
+        except Exception as exc:
+            logger.warning(
+                "Tavily search failed for query=%r: %s; falling back to Brave Search",
+                query,
+                exc,
+            )
+    else:
+        logger.debug("TAVILY_API_KEY not set; using Brave Search directly")
+
+    return await _brave_search(query, n_results)
+
+
 async def _extract_materials(search_results: list[dict]) -> list[dict]:
-    """Use LLM to extract structured materials from Brave search results."""
+    """Use LLM to extract structured educational materials from search results."""
     content_blocks = []
     for i, result in enumerate(search_results):
         title = result.get("title", "")
         url = result.get("url", "")
-        description = result.get("description", "")
-        content_blocks.append(f"### Source {i + 1}: {title}\nURL: {url}\n{description}")
+        content = result.get("content", "")
+        content_blocks.append(f"### Source {i + 1}: {title}\nURL: {url}\n{content}")
 
     combined = "\n\n".join(content_blocks)
     if not combined.strip():
@@ -131,13 +204,13 @@ async def search_study_materials(
     description: str,
     n_results: int = 5,
 ) -> list[dict]:
-    """Search for Chinese educational materials via Brave Search.
+    """Search for Chinese educational materials (Tavily → Brave fallback).
 
     Returns list[{title, source, url, key_points}]. Returns [] on any error.
     """
     try:
         query = _build_query(subject, grade, description)
-        search_results = await _brave_search(query, n_results=n_results)
+        search_results = await _search_with_fallback(query, n_results=n_results)
         if not search_results:
             return []
         return await _extract_materials(search_results)


### PR DESCRIPTION
## Summary

- Adds Tavily as the primary web search provider; Brave Search becomes the fallback
- Both providers normalize results to `{title, url, content}` — `_extract_materials()` is provider-agnostic
- Adds `TAVILY_API_KEY` config key; `BRAVE_API_KEY` unchanged

## Fallback logic (`_search_with_fallback`)

```
TAVILY_API_KEY set?
  YES → try Tavily
          HTTP 429 (quota) → warn + fall back to Brave
          any other error  → warn + fall back to Brave
          success          → return results
  NO  → go directly to Brave

Brave also fails or no key → return [] (best-effort, non-blocking)
```

## Why Tavily first

Tavily returns a `content` field with extracted page text per result — richer than Brave's `description` snippet — giving the downstream LLM extraction step more signal. Brave remains available as a free-tier overflow buffer.

## Setup

Add to `.env` (both optional; at least one recommended for production):
```
TAVILY_API_KEY=tvly-...    # https://app.tavily.com — free: 1 000 req/month
BRAVE_API_KEY=BSA...       # https://brave.com/search/api — free: 2 000 req/month
```

## Test plan

- [x] 117 tests pass
- [x] `ruff check` clean
- [ ] Manual: set only `TAVILY_API_KEY`, run wizard → verify Tavily used
- [ ] Manual: set only `BRAVE_API_KEY`, run wizard → verify Brave used
- [ ] Manual: mock Tavily 429 → verify fallback to Brave in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)